### PR TITLE
Update default image to fix RCE

### DIFF
--- a/godockerize.go
+++ b/godockerize.go
@@ -18,6 +18,11 @@ import (
 	"gopkg.in/urfave/cli.v2"
 )
 
+// Alpine doesn't do point releases, but if you are reading this, 3.8 downloads
+// 3.8.1 or newer, which contains the security fix for this RCE:
+// https://justi.cz/security/2018/09/13/alpine-apk-rce.html
+const baseDockerImage = "alpine:3.8"
+
 func main() {
 	app := &cli.App{
 		Name:    "godockerize",
@@ -38,7 +43,7 @@ func main() {
 					&cli.StringFlag{
 						Name:  "base",
 						Usage: "base Docker image name",
-						Value: "alpine:3.7",
+						Value: baseDockerImage,
 					},
 					&cli.StringSliceFlag{
 						Name:  "env",


### PR DESCRIPTION
Alpine 3.7 is vulnerable to RCE from a man-in-the-middle as described
here: https://justi.cz/security/2018/09/13/alpine-apk-rce.html

Update to Alpine 3.8.1, which fixes the issue. Alpine Docker does not
release tags for point releases, but you can verify the image is
updated correctly by running

    docker run alpine:3.8 cat /etc/alpine-release

which returns 3.8.1 for a fresh release.

Fixes #6.